### PR TITLE
Reindex Command to be Case Insensitive

### DIFF
--- a/src/CoandaCMS/Coanda/Pages/Artisan/Reindex.php
+++ b/src/CoandaCMS/Coanda/Pages/Artisan/Reindex.php
@@ -41,7 +41,7 @@ class Reindex extends Command {
     {
         $go = $this->ask('Are you sure you want to reindex all pages? Y/N (default: N)');
 
-        if ($go !== 'Y')
+        if (strcasecmp($go, 'Y') !== 0)
         {
             return;
         }


### PR DESCRIPTION
Really confusing that it fails when a lowercase 'y' is provided but the
Reindex script does not fire!
